### PR TITLE
[RTM] Run security check on CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
   - composer $COMPOSER_COMMAND --no-interaction
 
 script:
-  - php vendor/bin/security-checker security:check
+  - php vendor/bin/security-checker security:check --end-point=http://security.sensiolabs.org/check_lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: php
+
+git:
+  depth: 1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+sudo: false
+
+env:
+  global:
+    - COMPOSER_ALLOW_XDEBUG=0
+  matrix:
+    - COMPOSER_COMMAND=install
+    - COMPOSER_COMMAND=update
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+matrix:
+  fast_finish: true
+
+install:
+  - composer $COMPOSER_COMMAND --no-interaction
+
+script:
+  - php vendor/bin/security-checker security:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,17 @@ sudo: false
 env:
   global:
     - COMPOSER_ALLOW_XDEBUG=0
-  matrix:
-    - COMPOSER_COMMAND=install
-    - COMPOSER_COMMAND=update
-
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
 
 matrix:
+  include:
+    - php: 5.6
+      env: COMPOSER_COMMAND=install
+    - php: 7.0
+      env: COMPOSER_COMMAND=update
+    - php: 7.1
+      env: COMPOSER_COMMAND=update
+    - php: 7.2
+      env: COMPOSER_COMMAND=update
   fast_finish: true
 
 install:


### PR DESCRIPTION
This should help us to recognise early if we depend on packages with security issues. Running this automatically in CI is especially important for older supported PHP versions because locally most of us use the latest PHP version.