### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "contao/calendar-bundle": "^4.4",
         "contao/comments-bundle": "^4.4",
         "contao/faq-bundle": "^4.4",


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).