### PR TITLE
Ignore parameters.yml inside /config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# App config
-/config/parameters.yml
-/app/config/parameters.yml
-
 # Composer
 /.htaccess
 /composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # App config
+/config/parameters.yml
 /app/config/parameters.yml
 
 # Composer


### PR DESCRIPTION
This adds `/config/parameters.yml` to the project's .gitignore (in order to match Symfony 4 best practices not creating an app folder). 

We could also remove the old line completely. This depends on how much we want people to embrace this practice I guess. :wink: 