### PR TITLE
Use contao-setup binary with @php prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "prefer-stable": true,
     "scripts": {
         "post-install-cmd": [
-            "contao-setup"
+            "@php vendor/bin/contao-setup"
         ],
         "post-update-cmd": [
-            "contao-setup"
+            "@php vendor/bin/contao-setup"
         ]
     }
 }


### PR DESCRIPTION
see https://github.com/contao/contao/pull/2796

@leofeyer Is this correct, that the managed-edition repo does not have a `4.11` branch, yet?