### PR TITLE
Allow default Contao plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "contao/managed-edition",
-    "type": "project",
     "description": "Contao Managed Edition",
     "license": "LGPL-3.0-or-later",
+    "type": "project",
     "require": {
         "contao/calendar-bundle": "^4.9",
         "contao/comments-bundle": "^4.9",
@@ -16,6 +16,14 @@
     "conflict": {
         "contao-components/installer": "<1.3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true
+        }
+    },
     "extra": {
         "contao-component-dir": "assets"
     },
@@ -26,13 +34,5 @@
         "post-update-cmd": [
             "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
         ]
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "contao-components/installer": true,
-            "contao/manager-plugin": true,
-            "contao-community-alliance/composer-plugin": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,13 @@
         "post-update-cmd": [
             "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true,
+            "contao-community-alliance/composer-plugin": true
+        }
     }
 }


### PR DESCRIPTION
Otherwise our default plugins must be allowed first in Composer 2.2, see https://github.com/composer/composer/pull/10314
Not sure what other releases/branches this must go into, probably 4.9 and 4.12 as well?