### PR TITLE
Add .env.local to the list of ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Configuration
-/config/parameters.yml
 /.env.local
 
 # Composer
@@ -15,10 +14,8 @@
 /system/*
 !/system/config/
 /system/config/localconfig.php
-/system/config/tcpdf.php
 /templates/
 /var/
-/web/
 
 # Skip files
 /system/modules/*/.skip

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Configuration
 /config/parameters.yml
+/.env.local
 
 # Composer
 /vendor/


### PR DESCRIPTION
See https://github.com/contao/contao/pull/5066, where we now dump a `.env.local` file.